### PR TITLE
Support drawables as chart data

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/BarChartManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/BarChartManager.java
@@ -1,5 +1,6 @@
 package com.github.wuxudong.rncharts.charts;
 
+import android.content.Context;
 import android.view.View;
 
 import com.facebook.react.uimanager.ThemedReactContext;
@@ -27,7 +28,7 @@ public class BarChartManager extends BarLineChartBaseManager<BarChart, BarEntry>
     }
 
     @Override
-    DataExtract getDataExtract() {
+    DataExtract getDataExtract(Context context) {
         return new BarDataExtract();
     }
 

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/BarLineChartBaseManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/BarLineChartBaseManager.java
@@ -107,6 +107,11 @@ public abstract class BarLineChartBaseManager<T extends BarLineChartBase, U exte
         chart.setDoubleTapToZoomEnabled(enabled);
     }
 
+    @ReactProp(name = "highlightPerDragEnabled")
+    public void setHighlightPerDragEnabled(BarLineChartBase chart, boolean enabled) {
+        chart.setHighlightPerDragEnabled(enabled);
+    }
+
     @ReactProp(name = "zoom")
     public void setZoom(BarLineChartBase chart, ReadableMap propMap) {
         if (BridgeUtils.validate(propMap, ReadableType.Number, "scaleX") &&

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/BubbleChartManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/BubbleChartManager.java
@@ -1,5 +1,6 @@
 package com.github.wuxudong.rncharts.charts;
 
+import android.content.Context;
 
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.github.mikephil.charting.charts.BubbleChart;
@@ -26,7 +27,7 @@ public class BubbleChartManager extends ChartBaseManager<BubbleChart, BubbleEntr
 
 
     @Override
-    DataExtract getDataExtract() {
+    DataExtract getDataExtract(Context context) {
         return new BubbleDataExtract();
     }
 }

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/CandleStickChartManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/CandleStickChartManager.java
@@ -1,5 +1,7 @@
 package com.github.wuxudong.rncharts.charts;
 
+import android.content.Context;
+
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.github.mikephil.charting.charts.CandleStickChart;
 import com.github.mikephil.charting.data.CandleEntry;
@@ -25,7 +27,7 @@ public class CandleStickChartManager extends BarLineChartBaseManager<CandleStick
 
 
     @Override
-    DataExtract getDataExtract() {
+    DataExtract getDataExtract(Context context) {
         return new CandleDataExtract();
     }
 }

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
@@ -165,6 +165,16 @@ public abstract class ChartBaseManager<T extends Chart, U extends Entry> extends
         chart.setDragDecelerationFrictionCoef(coef);
     }
 
+    @ReactProp(name = "highlightPerTapEnabled")
+    public void setHighlightPerTapEnabled(Chart chart, boolean enabled) {
+        chart.setHighlightPerTapEnabled(enabled);
+    }
+
+    @ReactProp(name = "maxHighlightDistance")
+    public void setMaxHighlightDistance(Chart chart, float dist) {
+        chart.setMaxHighlightDistance(dist);
+    }
+
     /**
      * Animations docs: https://github.com/PhilJay/MPAndroidChart/wiki/Animations
      */

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
@@ -1,5 +1,6 @@
 package com.github.wuxudong.rncharts.charts;
 
+import android.content.Context;
 import android.content.res.ColorStateList;
 import android.os.Build;
 
@@ -31,7 +32,7 @@ import com.github.wuxudong.rncharts.utils.BridgeUtils;
 public abstract class ChartBaseManager<T extends Chart, U extends Entry> extends SimpleViewManager {
 
 
-    abstract DataExtract getDataExtract();
+    abstract DataExtract getDataExtract(Context context);
 
     /**
      * More details about legend customization: https://github.com/PhilJay/MPAndroidChart/wiki/Legend
@@ -388,7 +389,7 @@ public abstract class ChartBaseManager<T extends Chart, U extends Entry> extends
      */
     @ReactProp(name = "data")
     public void setData(Chart chart, ReadableMap propMap) {
-        chart.setData(getDataExtract().extract(propMap));
+        chart.setData(getDataExtract(chart.getContext()).extract(propMap));
         chart.invalidate();
     }
 

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/CombinedChartManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/CombinedChartManager.java
@@ -13,6 +13,7 @@ import com.github.wuxudong.rncharts.listener.RNOnChartValueSelectedListener;
 import com.github.wuxudong.rncharts.listener.RNOnChartGestureListener;
 
 public class CombinedChartManager extends BarLineChartBaseManager<CombinedChart, Entry> {
+    private ThemedReactContext mContext;
 
     @Override
     public String getName() {
@@ -21,6 +22,8 @@ public class CombinedChartManager extends BarLineChartBaseManager<CombinedChart,
 
     @Override
     protected CombinedChart createViewInstance(ThemedReactContext reactContext) {
+        mContext = reactContext;
+
         CombinedChart combinedChart = new CombinedChart(reactContext);
         combinedChart.setOnChartValueSelectedListener(new RNOnChartValueSelectedListener(combinedChart));
         combinedChart.setOnChartGestureListener(new RNOnChartGestureListener(combinedChart));
@@ -29,6 +32,6 @@ public class CombinedChartManager extends BarLineChartBaseManager<CombinedChart,
 
     @Override
     DataExtract getDataExtract() {
-        return new CombinedDataExtract();
+        return new CombinedDataExtract(mContext);
     }
 }

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/CombinedChartManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/CombinedChartManager.java
@@ -1,5 +1,6 @@
 package com.github.wuxudong.rncharts.charts;
 
+import android.content.Context;
 
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.github.mikephil.charting.charts.CombinedChart;
@@ -13,8 +14,6 @@ import com.github.wuxudong.rncharts.listener.RNOnChartValueSelectedListener;
 import com.github.wuxudong.rncharts.listener.RNOnChartGestureListener;
 
 public class CombinedChartManager extends BarLineChartBaseManager<CombinedChart, Entry> {
-    private ThemedReactContext mContext;
-
     @Override
     public String getName() {
         return "RNCombinedChart";
@@ -22,8 +21,6 @@ public class CombinedChartManager extends BarLineChartBaseManager<CombinedChart,
 
     @Override
     protected CombinedChart createViewInstance(ThemedReactContext reactContext) {
-        mContext = reactContext;
-
         CombinedChart combinedChart = new CombinedChart(reactContext);
         combinedChart.setOnChartValueSelectedListener(new RNOnChartValueSelectedListener(combinedChart));
         combinedChart.setOnChartGestureListener(new RNOnChartGestureListener(combinedChart));
@@ -31,7 +28,7 @@ public class CombinedChartManager extends BarLineChartBaseManager<CombinedChart,
     }
 
     @Override
-    DataExtract getDataExtract() {
-        return new CombinedDataExtract(mContext);
+    DataExtract getDataExtract(Context context) {
+        return new CombinedDataExtract(context);
     }
 }

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/LineChartManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/LineChartManager.java
@@ -1,5 +1,6 @@
 package com.github.wuxudong.rncharts.charts;
 
+import android.content.Context;
 
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.github.mikephil.charting.charts.LineChart;
@@ -11,8 +12,6 @@ import com.github.wuxudong.rncharts.listener.RNOnChartGestureListener;
 
 public class LineChartManager extends BarLineChartBaseManager<LineChart, Entry> {
 
-    private ThemedReactContext mContext;
-
     @Override
     public String getName() {
         return "RNLineChart";
@@ -20,7 +19,6 @@ public class LineChartManager extends BarLineChartBaseManager<LineChart, Entry> 
 
     @Override
     protected LineChart createViewInstance(ThemedReactContext reactContext) {
-        mContext = reactContext;
         LineChart lineChart =  new LineChart(reactContext);
         lineChart.setOnChartValueSelectedListener(new RNOnChartValueSelectedListener(lineChart));
         lineChart.setOnChartGestureListener(new RNOnChartGestureListener(lineChart));
@@ -28,7 +26,7 @@ public class LineChartManager extends BarLineChartBaseManager<LineChart, Entry> 
     }
 
     @Override
-    DataExtract getDataExtract() {
-        return new LineDataExtract(mContext);
+    DataExtract getDataExtract(Context context) {
+        return new LineDataExtract(context);
     }
 }

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/LineChartManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/LineChartManager.java
@@ -11,6 +11,8 @@ import com.github.wuxudong.rncharts.listener.RNOnChartGestureListener;
 
 public class LineChartManager extends BarLineChartBaseManager<LineChart, Entry> {
 
+    private ThemedReactContext mContext;
+
     @Override
     public String getName() {
         return "RNLineChart";
@@ -18,6 +20,7 @@ public class LineChartManager extends BarLineChartBaseManager<LineChart, Entry> 
 
     @Override
     protected LineChart createViewInstance(ThemedReactContext reactContext) {
+        mContext = reactContext;
         LineChart lineChart =  new LineChart(reactContext);
         lineChart.setOnChartValueSelectedListener(new RNOnChartValueSelectedListener(lineChart));
         lineChart.setOnChartGestureListener(new RNOnChartGestureListener(lineChart));
@@ -26,6 +29,6 @@ public class LineChartManager extends BarLineChartBaseManager<LineChart, Entry> 
 
     @Override
     DataExtract getDataExtract() {
-        return new LineDataExtract();
+        return new LineDataExtract(mContext);
     }
 }

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/PieChartManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/PieChartManager.java
@@ -1,6 +1,6 @@
 package com.github.wuxudong.rncharts.charts;
 
-
+import android.content.Context;
 import android.view.View;
 
 import com.facebook.react.uimanager.ThemedReactContext;
@@ -29,7 +29,7 @@ public class PieChartManager extends ChartBaseManager<PieChart, PieEntry> {
     }
 
     @Override
-    DataExtract getDataExtract() {
+    DataExtract getDataExtract(Context context) {
         return new PieDataExtract();
     }
 

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/RadarChartManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/RadarChartManager.java
@@ -1,5 +1,6 @@
 package com.github.wuxudong.rncharts.charts;
 
+import android.content.Context;
 
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.ThemedReactContext;
@@ -29,7 +30,7 @@ public class RadarChartManager extends YAxisChartBase<RadarChart, RadarEntry> {
     }
 
     @Override
-    DataExtract getDataExtract() {
+    DataExtract getDataExtract(Context context) {
         return new RadarDataExtract();
     }
 

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/ScatterChartManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/ScatterChartManager.java
@@ -1,5 +1,6 @@
 package com.github.wuxudong.rncharts.charts;
 
+import android.content.Context;
 
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
@@ -23,8 +24,6 @@ import java.util.ArrayList;
 
 public class ScatterChartManager extends BarLineChartBaseManager<ScatterChart, Entry> {
 
-    private ThemedReactContext mContext;
-
     @Override
     public String getName() {
         return "RNScatterChart";
@@ -32,8 +31,6 @@ public class ScatterChartManager extends BarLineChartBaseManager<ScatterChart, E
 
     @Override
     protected ScatterChart createViewInstance(ThemedReactContext reactContext) {
-        mContext = reactContext;
-
         ScatterChart scatterChart = new ScatterChart(reactContext);
         scatterChart.setOnChartValueSelectedListener(new RNOnChartValueSelectedListener(scatterChart));
         scatterChart.setOnChartGestureListener(new RNOnChartGestureListener(scatterChart));
@@ -42,7 +39,7 @@ public class ScatterChartManager extends BarLineChartBaseManager<ScatterChart, E
 
 
     @Override
-    DataExtract getDataExtract() {
-        return new ScatterDataExtract(mContext);
+    DataExtract getDataExtract(Context context) {
+        return new ScatterDataExtract(context);
     }
 }

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/ScatterChartManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/ScatterChartManager.java
@@ -23,6 +23,8 @@ import java.util.ArrayList;
 
 public class ScatterChartManager extends BarLineChartBaseManager<ScatterChart, Entry> {
 
+    private ThemedReactContext mContext;
+
     @Override
     public String getName() {
         return "RNScatterChart";
@@ -30,6 +32,8 @@ public class ScatterChartManager extends BarLineChartBaseManager<ScatterChart, E
 
     @Override
     protected ScatterChart createViewInstance(ThemedReactContext reactContext) {
+        mContext = reactContext;
+
         ScatterChart scatterChart = new ScatterChart(reactContext);
         scatterChart.setOnChartValueSelectedListener(new RNOnChartValueSelectedListener(scatterChart));
         scatterChart.setOnChartGestureListener(new RNOnChartGestureListener(scatterChart));
@@ -39,6 +43,6 @@ public class ScatterChartManager extends BarLineChartBaseManager<ScatterChart, E
 
     @Override
     DataExtract getDataExtract() {
-        return new ScatterDataExtract();
+        return new ScatterDataExtract(mContext);
     }
 }

--- a/android/src/main/java/com/github/wuxudong/rncharts/data/CombinedDataExtract.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/data/CombinedDataExtract.java
@@ -3,6 +3,7 @@ package com.github.wuxudong.rncharts.data;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
+import com.facebook.react.uimanager.ThemedReactContext;
 import com.github.mikephil.charting.data.ChartData;
 import com.github.mikephil.charting.data.CombinedData;
 import com.github.mikephil.charting.data.Entry;
@@ -17,11 +18,19 @@ import java.util.ArrayList;
  */
 
 public class CombinedDataExtract extends DataExtract<CombinedData, Entry> {
-    private LineDataExtract lineDataExtract = new LineDataExtract();
+    private LineDataExtract lineDataExtract;
     private BarDataExtract barDataExtract = new BarDataExtract();
-    private ScatterDataExtract scatterDataExtract = new ScatterDataExtract();
+    private ScatterDataExtract scatterDataExtract;
     private CandleDataExtract candleDataExtract = new CandleDataExtract();
     private BubbleDataExtract bubbleDataExtract = new BubbleDataExtract();
+
+    public CombinedDataExtract() { }
+
+    public CombinedDataExtract(ThemedReactContext context) {
+        super();
+        lineDataExtract = new LineDataExtract(context);
+        scatterDataExtract = new ScatterDataExtract(context);
+    }
 
     @Override
     public CombinedData extract(ReadableMap propMap) {

--- a/android/src/main/java/com/github/wuxudong/rncharts/data/CombinedDataExtract.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/data/CombinedDataExtract.java
@@ -3,7 +3,6 @@ package com.github.wuxudong.rncharts.data;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
-import com.facebook.react.uimanager.ThemedReactContext;
 import com.github.mikephil.charting.data.ChartData;
 import com.github.mikephil.charting.data.CombinedData;
 import com.github.mikephil.charting.data.Entry;
@@ -11,6 +10,7 @@ import com.github.mikephil.charting.data.LineData;
 import com.github.mikephil.charting.interfaces.datasets.IDataSet;
 import com.github.wuxudong.rncharts.utils.BridgeUtils;
 
+import android.content.Context;
 import java.util.ArrayList;
 
 /**
@@ -26,7 +26,7 @@ public class CombinedDataExtract extends DataExtract<CombinedData, Entry> {
 
     public CombinedDataExtract() { }
 
-    public CombinedDataExtract(ThemedReactContext context) {
+    public CombinedDataExtract(Context context) {
         super();
         lineDataExtract = new LineDataExtract(context);
         scatterDataExtract = new ScatterDataExtract(context);

--- a/android/src/main/java/com/github/wuxudong/rncharts/data/DataExtract.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/data/DataExtract.java
@@ -109,6 +109,9 @@ public abstract class DataExtract<D extends ChartData, U extends Entry> {
                 m.postTranslate(offsetLeft, offsetTop);
 
                 Paint p = new Paint();
+                p.setAntiAlias(true);
+                p.setDither(true);
+                p.setFilterBitmap(true);
                 p.setColorFilter(new PorterDuffColorFilter(color, PorterDuff.Mode.SRC_ATOP));
                 Log.d("React-native-charts-wrapper", "drew bitmap " + color);
                 c.drawBitmap(b, m, p);
@@ -130,6 +133,9 @@ public abstract class DataExtract<D extends ChartData, U extends Entry> {
         float cy = icon.hasKey("cy") ? (float) icon.getDouble("cy") : 0f;
 
         Paint p = new Paint();
+        p.setAntiAlias(true);
+        p.setDither(true);
+        p.setFilterBitmap(true);
         p.setColorFilter(new PorterDuffColorFilter(color, PorterDuff.Mode.SRC_ATOP));
         c.drawCircle(cx, cy, radius, p);
     }
@@ -144,6 +150,10 @@ public abstract class DataExtract<D extends ChartData, U extends Entry> {
         float cy = icon.hasKey("cy") ? (float) icon.getDouble("cy") : 0f;
 
         Paint p = new Paint();
+        p.setAntiAlias(true);
+        p.setDither(true);
+        p.setFilterBitmap(true);
+
         if (fontPath != null) {
             Typeface tf = Typeface.createFromAsset(context.getAssets(), fontPath);
             p.setTypeface(tf);
@@ -181,7 +191,11 @@ public abstract class DataExtract<D extends ChartData, U extends Entry> {
                 }
             }
 
-            drawable = new BitmapDrawable(context.getResources(), b);
+            BitmapDrawable bd = new BitmapDrawable(context.getResources(), b);
+            bd.setAntiAlias(true);
+            bd.setFilterBitmap(true);
+            drawable = (Drawable) bd;
+
         }
         return drawable;
     }

--- a/android/src/main/java/com/github/wuxudong/rncharts/data/DataExtract.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/data/DataExtract.java
@@ -3,16 +3,15 @@ package com.github.wuxudong.rncharts.data;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
-import com.facebook.react.uimanager.ThemedReactContext;
 import com.github.mikephil.charting.data.ChartData;
 import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.interfaces.datasets.IDataSet;
 import com.github.wuxudong.rncharts.utils.BridgeUtils;
 
+import android.content.Context;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffColorFilter;
-
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
@@ -88,7 +87,7 @@ public abstract class DataExtract<D extends ChartData, U extends Entry> {
     abstract U createEntry(ReadableArray values, int index);
 
 
-    private void drawBitmap(ThemedReactContext context, Canvas c, ReadableMap icon) {
+    private void drawBitmap(Context context, Canvas c, ReadableMap icon) {
         Bitmap b = null;
         InputStream is = null;
         String path = icon.hasKey("path") ? icon.getString("path") : null;
@@ -140,7 +139,7 @@ public abstract class DataExtract<D extends ChartData, U extends Entry> {
         c.drawCircle(cx, cy, radius, p);
     }
 
-    private void drawText(ThemedReactContext context, Canvas c, ReadableMap icon) {
+    private void drawText(Context context, Canvas c, ReadableMap icon) {
         String fontPath = icon.hasKey("path") ? icon.getString("path") : null;
         String text = icon.hasKey("text") ? icon.getString("text") : null;
         int color = icon.hasKey("color") ? icon.getInt("color") : Color.WHITE;
@@ -167,7 +166,7 @@ public abstract class DataExtract<D extends ChartData, U extends Entry> {
         }
     }
 
-    protected Drawable getIconDrawable(ThemedReactContext context, ReadableMap map) {
+    protected Drawable getIconDrawable(Context context, ReadableMap map) {
         if (!map.hasKey("icons")) {
             return null;
         }

--- a/android/src/main/java/com/github/wuxudong/rncharts/data/DataExtract.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/data/DataExtract.java
@@ -3,11 +3,22 @@ package com.github.wuxudong.rncharts.data;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
+import com.facebook.react.uimanager.ThemedReactContext;
 import com.github.mikephil.charting.data.ChartData;
 import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.interfaces.datasets.IDataSet;
 import com.github.wuxudong.rncharts.utils.BridgeUtils;
 
+import android.graphics.Color;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffColorFilter;
+
+import android.graphics.Bitmap;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+import android.util.Log;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 
 /**
@@ -72,5 +83,37 @@ public abstract class DataExtract<D extends ChartData, U extends Entry> {
     abstract U createEntry(ReadableArray values, int index);
 
 
+    protected Drawable getIconDrawable(ThemedReactContext context, ReadableMap map) {
+        if (!map.hasKey("icon")) {
+            return null;
+        }
 
+        String iconName = map.getString("icon");
+
+        Drawable drawable = null;
+        InputStream is = null;
+        Bitmap b = null;
+        Bitmap sb = null;
+        if (context != null && iconName != null) {
+            try {
+                int color = map.hasKey("iconColor") ? map.getInt("iconColor") : Color.WHITE;
+                int size = map.hasKey("iconSize") ? map.getInt("iconSize") : 100;
+                is = context.getAssets().open(iconName);
+                BitmapDrawable bd = new BitmapDrawable(context.getResources(), is);
+                b = bd.getBitmap();
+                sb = Bitmap.createScaledBitmap(b, size, size, false);
+                bd = new BitmapDrawable(context.getResources(), sb);
+                drawable = (Drawable) bd;
+                drawable.setColorFilter(new PorterDuffColorFilter(color, PorterDuff.Mode.SRC_ATOP));
+            } catch (IOException e) {
+                Log.e("wuxudong/react-native-charts-wrapper", "Error creating icon drawable", e);
+            } finally {
+                if (is != null) {
+                    try { is.close(); }
+                    catch (IOException e) { Log.e("wuxudong/react-native-charts-wrapper", "Error closing stream", e); } }
+                if (b != null) { b.recycle(); }
+            }
+        }
+        return drawable;
+    }
 }

--- a/android/src/main/java/com/github/wuxudong/rncharts/data/LineDataExtract.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/data/LineDataExtract.java
@@ -3,6 +3,7 @@ package com.github.wuxudong.rncharts.data;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
+import com.facebook.react.uimanager.ThemedReactContext;
 import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.data.LineData;
 import com.github.mikephil.charting.data.LineDataSet;
@@ -18,6 +19,12 @@ import java.util.ArrayList;
  */
 
 public class LineDataExtract extends DataExtract<LineData, Entry> {
+    private ThemedReactContext mContext;
+
+    public LineDataExtract(ThemedReactContext context) {
+        mContext = context
+    }
+
     @Override
     LineData createData() {
         return new LineData();
@@ -93,7 +100,9 @@ public class LineDataExtract extends DataExtract<LineData, Entry> {
             if (map.hasKey("x")) {
                 x = (float) map.getDouble("x");
             }
-            entry = new Entry(x, (float) map.getDouble("y"), ConversionUtil.toMap(map));
+            String iconName = map.getString("icon");
+            Drawable drawable = mContext.getResources().getIdentifier(iconName, "drawable", mContext.getPackageName());
+            entry = new Entry(x, (float) map.getDouble("y"), drawable, ConversionUtil.toMap(map));
         } else if (ReadableType.Number.equals(values.getType(index))) {
             entry = new Entry(x, (float) values.getDouble(index));
         } else {

--- a/android/src/main/java/com/github/wuxudong/rncharts/data/LineDataExtract.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/data/LineDataExtract.java
@@ -1,6 +1,5 @@
 package com.github.wuxudong.rncharts.data;
 
-import android.graphics.drawable.Drawable;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
@@ -13,8 +12,7 @@ import com.github.wuxudong.rncharts.utils.BridgeUtils;
 import com.github.wuxudong.rncharts.utils.ChartDataSetConfigUtils;
 import com.github.wuxudong.rncharts.utils.ConversionUtil;
 
-import java.io.IOException;
-import java.io.InputStream;
+import android.graphics.drawable.Drawable;
 import java.util.ArrayList;
 
 /**
@@ -25,7 +23,7 @@ public class LineDataExtract extends DataExtract<LineData, Entry> {
     private ThemedReactContext mContext;
 
     public LineDataExtract() { }
-    
+
     public LineDataExtract(ThemedReactContext context) {
         super();
         mContext = context;
@@ -106,27 +104,8 @@ public class LineDataExtract extends DataExtract<LineData, Entry> {
             if (map.hasKey("x")) {
                 x = (float) map.getDouble("x");
             }
-            String iconName = null;
 
-            if (map.hasKey("icon")) {
-                iconName = map.getString("icon");
-            }
-            
-            Drawable drawable = null;
-            InputStream is = null;
-            if (mContext != null && iconName != null) {
-                try {
-                    is = mContext.getAssets().open(iconName);
-                    drawable = Drawable.createFromStream(is, null);
-                    drawable.setBounds(0, 0, 500, 500);
-                } catch (IOException e) {
-                    
-                } finally {
-                    if (is != null) {
-                        try { is.close(); } catch (IOException e) { }
-                    }
-                }
-            }
+            Drawable drawable = getIconDrawable(mContext, map);
             entry = new Entry(x, (float) map.getDouble("y"), drawable, ConversionUtil.toMap(map));
         } else if (ReadableType.Number.equals(values.getType(index))) {
             entry = new Entry(x, (float) values.getDouble(index));

--- a/android/src/main/java/com/github/wuxudong/rncharts/data/LineDataExtract.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/data/LineDataExtract.java
@@ -3,7 +3,6 @@ package com.github.wuxudong.rncharts.data;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
-import com.facebook.react.uimanager.ThemedReactContext;
 import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.data.LineData;
 import com.github.mikephil.charting.data.LineDataSet;
@@ -12,6 +11,7 @@ import com.github.wuxudong.rncharts.utils.BridgeUtils;
 import com.github.wuxudong.rncharts.utils.ChartDataSetConfigUtils;
 import com.github.wuxudong.rncharts.utils.ConversionUtil;
 
+import android.content.Context;
 import android.graphics.drawable.Drawable;
 import java.util.ArrayList;
 
@@ -20,11 +20,11 @@ import java.util.ArrayList;
  */
 
 public class LineDataExtract extends DataExtract<LineData, Entry> {
-    private ThemedReactContext mContext;
+    private Context mContext;
 
     public LineDataExtract() { }
 
-    public LineDataExtract(ThemedReactContext context) {
+    public LineDataExtract(Context context) {
         super();
         mContext = context;
     }

--- a/android/src/main/java/com/github/wuxudong/rncharts/data/LineDataExtract.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/data/LineDataExtract.java
@@ -1,5 +1,6 @@
 package com.github.wuxudong.rncharts.data;
 
+import android.graphics.drawable.Drawable;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
@@ -12,6 +13,8 @@ import com.github.wuxudong.rncharts.utils.BridgeUtils;
 import com.github.wuxudong.rncharts.utils.ChartDataSetConfigUtils;
 import com.github.wuxudong.rncharts.utils.ConversionUtil;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 
 /**
@@ -21,8 +24,11 @@ import java.util.ArrayList;
 public class LineDataExtract extends DataExtract<LineData, Entry> {
     private ThemedReactContext mContext;
 
+    public LineDataExtract() { }
+    
     public LineDataExtract(ThemedReactContext context) {
-        mContext = context
+        super();
+        mContext = context;
     }
 
     @Override
@@ -100,8 +106,27 @@ public class LineDataExtract extends DataExtract<LineData, Entry> {
             if (map.hasKey("x")) {
                 x = (float) map.getDouble("x");
             }
-            String iconName = map.getString("icon");
-            Drawable drawable = mContext.getResources().getIdentifier(iconName, "drawable", mContext.getPackageName());
+            String iconName = null;
+
+            if (map.hasKey("icon")) {
+                iconName = map.getString("icon");
+            }
+            
+            Drawable drawable = null;
+            InputStream is = null;
+            if (mContext != null && iconName != null) {
+                try {
+                    is = mContext.getAssets().open(iconName);
+                    drawable = Drawable.createFromStream(is, null);
+                    drawable.setBounds(0, 0, 500, 500);
+                } catch (IOException e) {
+                    
+                } finally {
+                    if (is != null) {
+                        try { is.close(); } catch (IOException e) { }
+                    }
+                }
+            }
             entry = new Entry(x, (float) map.getDouble("y"), drawable, ConversionUtil.toMap(map));
         } else if (ReadableType.Number.equals(values.getType(index))) {
             entry = new Entry(x, (float) values.getDouble(index));

--- a/android/src/main/java/com/github/wuxudong/rncharts/data/ScatterDataExtract.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/data/ScatterDataExtract.java
@@ -3,7 +3,6 @@ package com.github.wuxudong.rncharts.data;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
-import com.facebook.react.uimanager.ThemedReactContext;
 import com.github.mikephil.charting.charts.ScatterChart;
 import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.data.ScatterData;
@@ -13,6 +12,7 @@ import com.github.wuxudong.rncharts.utils.BridgeUtils;
 import com.github.wuxudong.rncharts.utils.ChartDataSetConfigUtils;
 import com.github.wuxudong.rncharts.utils.ConversionUtil;
 
+import android.content.Context;
 import android.graphics.drawable.Drawable;
 import java.util.ArrayList;
 
@@ -21,11 +21,11 @@ import java.util.ArrayList;
  */
 
 public class ScatterDataExtract extends DataExtract<ScatterData, Entry> {
-    private ThemedReactContext mContext;
+    private Context mContext;
 
     public ScatterDataExtract() { }
 
-    public ScatterDataExtract(ThemedReactContext context) {
+    public ScatterDataExtract(Context context) {
         super();
         mContext = context;
     }

--- a/android/src/main/java/com/github/wuxudong/rncharts/data/ScatterDataExtract.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/data/ScatterDataExtract.java
@@ -3,6 +3,7 @@ package com.github.wuxudong.rncharts.data;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
+import com.facebook.react.uimanager.ThemedReactContext;
 import com.github.mikephil.charting.charts.ScatterChart;
 import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.data.ScatterData;
@@ -12,6 +13,7 @@ import com.github.wuxudong.rncharts.utils.BridgeUtils;
 import com.github.wuxudong.rncharts.utils.ChartDataSetConfigUtils;
 import com.github.wuxudong.rncharts.utils.ConversionUtil;
 
+import android.graphics.drawable.Drawable;
 import java.util.ArrayList;
 
 /**
@@ -19,6 +21,15 @@ import java.util.ArrayList;
  */
 
 public class ScatterDataExtract extends DataExtract<ScatterData, Entry> {
+    private ThemedReactContext mContext;
+
+    public ScatterDataExtract() { }
+
+    public ScatterDataExtract(ThemedReactContext context) {
+        super();
+        mContext = context;
+    }
+
     @Override
     ScatterData createData() {
         return new ScatterData();
@@ -62,7 +73,9 @@ public class ScatterDataExtract extends DataExtract<ScatterData, Entry> {
             if (map.hasKey("x")) {
                 x = (float) map.getDouble("x");
             }
-            entry = new Entry(x, (float) map.getDouble("y"), ConversionUtil.toMap(map));
+
+            Drawable drawable = getIconDrawable(mContext, map);
+            entry = new Entry(x, (float) map.getDouble("y"), drawable, ConversionUtil.toMap(map));
         } else if (ReadableType.Number.equals(values.getType(index))) {
             entry = new Entry(x, (float) values.getDouble(index));
         } else {

--- a/android/src/main/java/com/github/wuxudong/rncharts/utils/ChartDataSetConfigUtils.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/utils/ChartDataSetConfigUtils.java
@@ -28,11 +28,11 @@ public class ChartDataSetConfigUtils {
         }
 
         // TODO more config to add: https://github.com/PhilJay/MPAndroidChart/wiki/The-DataSet-class
-        
+
         if (BridgeUtils.validate(config, ReadableType.Boolean, "drawValues")) {
             dataSet.setDrawValues(config.getBoolean("drawValues"));
         }
-        
+
         if (BridgeUtils.validate(config, ReadableType.Boolean, "drawIcons")) {
             dataSet.setDrawIcons(config.getBoolean("drawIcons"));
         }

--- a/android/src/main/java/com/github/wuxudong/rncharts/utils/ChartDataSetConfigUtils.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/utils/ChartDataSetConfigUtils.java
@@ -28,9 +28,13 @@ public class ChartDataSetConfigUtils {
         }
 
         // TODO more config to add: https://github.com/PhilJay/MPAndroidChart/wiki/The-DataSet-class
-
+        
         if (BridgeUtils.validate(config, ReadableType.Boolean, "drawValues")) {
             dataSet.setDrawValues(config.getBoolean("drawValues"));
+        }
+        
+        if (BridgeUtils.validate(config, ReadableType.Boolean, "drawIcons")) {
+            dataSet.setDrawIcons(config.getBoolean("drawIcons"));
         }
 
         if (BridgeUtils.validate(config, ReadableType.Boolean, "highlightEnabled")) {

--- a/lib/BarLineChartBase.js
+++ b/lib/BarLineChartBase.js
@@ -29,6 +29,7 @@ const iface = {
     dragEnabled: PropTypes.bool,
     pinchZoom: PropTypes.bool,
     doubleTapToZoomEnabled: PropTypes.bool,
+    highlightPerDragEnabled: PropTypes.bool,
 
     yAxis: PropTypes.shape({
       left: PropTypes.shape(yAxisIface),

--- a/lib/ChartBase.js
+++ b/lib/ChartBase.js
@@ -68,6 +68,9 @@ const chartIface = {
       }
     },
 
+    highlightPerTapEnabled: PropTypes.bool,
+    maxHighlightDistance: PropTypes.number,
+
     chartDescription: PropTypes.shape(descriptionIface),
 
     legend: PropTypes.shape(legendIface),

--- a/lib/ChartDataConfig.js
+++ b/lib/ChartDataConfig.js
@@ -175,6 +175,7 @@ const scatterData = PropTypes.shape({
         PropTypes.shape({
           x: PropTypes.number,
           y: PropTypes.number.isRequired,
+          icon: PropTypes.string,
           marker: PropTypes.string,
         }),
         PropTypes.number

--- a/lib/ChartDataConfig.js
+++ b/lib/ChartDataConfig.js
@@ -9,6 +9,7 @@ const lineData = PropTypes.shape({
         PropTypes.shape({
           x: PropTypes.number,
           y: PropTypes.number.isRequired,
+          icon: PropTypes.string,
           marker: PropTypes.string
         }),
         PropTypes.number

--- a/lib/ChartDataSetConfig.js
+++ b/lib/ChartDataSetConfig.js
@@ -10,6 +10,7 @@ const chartDataSetConfig = {
     colors: PropTypes.arrayOf(PropTypes.number),
     highlightEnabled:PropTypes.bool,
     drawValues: PropTypes.bool,
+    drawIcons: PropTypes.bool,
     valueTextSize:PropTypes.number,
     valueTextColor:PropTypes.number,
     visible:PropTypes.bool,


### PR DESCRIPTION
MPAndroid supports `drawIcons` and takes in a drawable as part of entry data. Customized the wrapper library to support our desired shapes we'll want to draw (circle, text, and image).

usage:
config: `{... drawIcons true}` 
entry data:
```
[{:x _ :y _
  :iconSize 50
  :icons [{:type "circle" :color (rn/process-color "black") :radius 10 :cx 5 :cy 5}
          {:type "bitmap" :color (rn/process-color "red") :size 10 :path "icon_circle.png" :left 4 :top 0}
          {:type "text" :text "Yes" :color (rn/process-color "blue") :path "fonts/sans_serif.ttf" :size 10 :cx 3 :cy 5}]}
 ...]
```
Icons will be layered on top of each other, so circle is drawn on bottom, and text on top.