### PR TITLE
Add custom image marker class to allow varying drawables

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
@@ -319,11 +319,6 @@ public abstract class ChartBaseManager<T extends Chart, U extends Entry> extends
             return;
         }
 
-        if (!BridgeUtils.validate(propMap, ReadableType.String, "resourceName")) {
-            throw new IllegalArgumentException("expecting resourceName for imageMarker");
-        }
-
-        String resourceName = propMap.getString("resourceName");
         Float offsetX = 0f;
         Float offsetY = 0f;
         Float width = 0f;
@@ -347,10 +342,7 @@ public abstract class ChartBaseManager<T extends Chart, U extends Entry> extends
         }
 
         RNConditionalMarkerImage marker = new RNConditionalMarkerImage(
-            chart.getContext(), 
-            chart.getContext()
-            .getResources()
-            .getIdentifier(resourceName, "drawable", chart.getContext().getPackageName()),
+            chart.getContext(),
             excludes);
         
         marker.setOffset(offsetX, offsetY);

--- a/android/src/main/java/com/github/wuxudong/rncharts/markers/RNConditionalMarkerImage.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/markers/RNConditionalMarkerImage.java
@@ -23,7 +23,7 @@ import java.util.Set;
  *  1. highlight is on a excluded dataset
  *  2. entry's markerHighlightSource does not match highligh's source
  */
-public class RNConditionalMarkerImage extends MarkerImage {
+public class RNConditionalMarkerImage extends RNImageMarker {
     
     private boolean mSkipDraw;
     /*
@@ -59,8 +59,8 @@ public class RNConditionalMarkerImage extends MarkerImage {
         return null;
     }
 
-    public RNConditionalMarkerImage(Context context, int drawableResourceId, ReadableArray excludesProp) {
-        super(context, drawableResourceId);
+    public RNConditionalMarkerImage(Context context, ReadableArray excludesProp) {
+        super(context);
         
         mSkipDraw = false;
         mExcludes = parseExcludesProp(excludesProp);
@@ -101,8 +101,7 @@ public class RNConditionalMarkerImage extends MarkerImage {
             }
         }
 
-
-        super.refreshContent(e, h);
+        if (!mSkipDraw) super.refreshContent(e, h);
     }
     
     @Override

--- a/android/src/main/java/com/github/wuxudong/rncharts/markers/RNImageMarker.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/markers/RNImageMarker.java
@@ -1,0 +1,173 @@
+package com.github.wuxudong.rncharts.markers;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+
+import com.github.mikephil.charting.charts.Chart;
+import com.github.mikephil.charting.components.IMarker;
+import com.github.mikephil.charting.data.Entry;
+import com.github.mikephil.charting.highlight.Highlight;
+import com.github.mikephil.charting.utils.FSize;
+import com.github.mikephil.charting.utils.MPPointF;
+
+import java.lang.ref.WeakReference;
+import java.util.Map;
+
+/**
+ * Extends com.github.mikephil.charting.components.MarkerImage to allow
+ * varying drawables given data entry.
+ *
+ * Entries want to have their custom image marker drawn must specify
+ * markerName as a valid drawable resource name.
+ *
+ * Created by idealllee on 4/6/18.
+ */
+
+public class RNImageMarker implements IMarker {
+
+    private Context mContext;
+    private Drawable mDrawable;
+
+    private MPPointF mOffset = new MPPointF();
+    private MPPointF mOffset2 = new MPPointF();
+    private WeakReference<Chart> mWeakChart;
+
+    private FSize mSize = new FSize();
+    private Rect mDrawableBoundsCache = new Rect();
+
+    public RNImageMarker(Context context) {
+        mContext = context;
+    }
+
+    public void setOffset(MPPointF offset) {
+        mOffset = offset;
+
+        if (mOffset == null) {
+            mOffset = new MPPointF();
+        }
+    }
+
+    public void setOffset(float offsetX, float offsetY) {
+        mOffset.x = offsetX;
+        mOffset.y = offsetY;
+    }
+
+    @Override
+    public MPPointF getOffset() {
+        return mOffset;
+    }
+
+    public void setSize(FSize size) {
+        mSize = size;
+
+        if (mSize == null) {
+            mSize = new FSize();
+        }
+    }
+
+    public FSize getSize() {
+        return mSize;
+    }
+
+    public void setChartView(Chart chart) {
+        mWeakChart = new WeakReference<>(chart);
+    }
+
+    public Chart getChartView() {
+        return mWeakChart == null ? null : mWeakChart.get();
+    }
+
+    @Override
+    public MPPointF getOffsetForDrawingAtPoint(float posX, float posY) {
+
+        MPPointF offset = getOffset();
+        mOffset2.x = offset.x;
+        mOffset2.y = offset.y;
+
+        Chart chart = getChartView();
+
+        float width = mSize.width;
+        float height = mSize.height;
+
+        if (width == 0.f && mDrawable != null) {
+            width = mDrawable.getIntrinsicWidth();
+        }
+        if (height == 0.f && mDrawable != null) {
+            height = mDrawable.getIntrinsicHeight();
+        }
+
+        if (posX + mOffset2.x < 0) {
+            mOffset2.x = - posX;
+        } else if (chart != null && posX + width + mOffset2.x > chart.getWidth()) {
+            mOffset2.x = chart.getWidth() - posX - width;
+        }
+
+        if (posY + mOffset2.y < 0) {
+            mOffset2.y = - posY;
+        } else if (chart != null && posY + height + mOffset2.y > chart.getHeight()) {
+            mOffset2.y = chart.getHeight() - posY - height;
+        }
+
+        return mOffset2;
+    }
+
+    @Override
+    public void refreshContent(Entry e, Highlight highlight) {
+        Map eData = (e.getData() instanceof Map) ? (Map)e.getData() : null;
+        String path = (String) eData.get("markerName");
+
+        if (path == null){
+            return;
+        }
+
+        int resId = mContext.getResources().getIdentifier(path, "drawable", mContext.getPackageName());
+        if (resId == 0) {
+            return;
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+        {
+            mDrawable = mContext.getResources().getDrawable(resId, null);
+        }
+        else
+        {
+            mDrawable = mContext.getResources().getDrawable(resId);
+        }
+    }
+
+    @Override
+    public void draw(Canvas canvas, float posX, float posY) {
+
+        if (mDrawable == null) return;
+
+        MPPointF offset = getOffsetForDrawingAtPoint(posX, posY);
+
+        float width = mSize.width;
+        float height = mSize.height;
+
+        if (width == 0.f && mDrawable != null) {
+            width = mDrawable.getIntrinsicWidth();
+        }
+        if (height == 0.f && mDrawable != null) {
+            height = mDrawable.getIntrinsicHeight();
+        }
+
+        mDrawable.copyBounds(mDrawableBoundsCache);
+        mDrawable.setBounds(
+                mDrawableBoundsCache.left,
+                mDrawableBoundsCache.top,
+                mDrawableBoundsCache.left + (int)width,
+                mDrawableBoundsCache.top + (int)height);
+
+        int saveId = canvas.save();
+        // translate to the correct position and draw
+        canvas.translate(posX + offset.x, posY + offset.y);
+        mDrawable.draw(canvas);
+        canvas.restoreToCount(saveId);
+
+        mDrawable.setBounds(mDrawableBoundsCache);
+    }
+}

--- a/android/src/main/java/com/github/wuxudong/rncharts/markers/RNImageMarker.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/markers/RNImageMarker.java
@@ -18,7 +18,8 @@ import java.util.Map;
 
 /**
  * Extends com.github.mikephil.charting.components.MarkerImage to allow
- * varying drawables given data entry.
+ * varying drawables given data entry. (note: only refreshContent was updated
+ * and the rest copied from MarkerImage)
  *
  * Entries want to have their custom image marker drawn must specify
  * markerName as a valid drawable resource name.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/indiemoney/react-native-charts-wrapper"
   },
-  "version": "0.2.13-SNAPSHOT.12",
+  "version": "0.2.13-SNAPSHOT.13",
   "description": "Fork off of react-native-charts-wrapper",
   "author": "wuxudong",
   "license": "MIT",


### PR DESCRIPTION
Copied from https://github.com/PhilJay/MPAndroidChart/blob/master/MPChartLib/src/main/java/com/github/mikephil/charting/components/MarkerImage.java and only updated its `refreshContent` method. 

Can't extend because `mDrawable` was private and no way to reset in original class. 

@jlo1 @drhops 